### PR TITLE
DEV-25130: Refactor function for Python 2 + 3 compatiblity

### DIFF
--- a/silverpop/utils.py
+++ b/silverpop/utils.py
@@ -9,21 +9,17 @@ def replace_in_nested_mapping(mapping, values):
     Recursively replace "variable names" (strings that have the same value as
     keys in a dict) with their values in a nested 2-tuple mapping.
     """
-    mapping = OrderedDict(mapping)
+    definitions = {}
 
-    for mapping_key, mapping_value in mapping.items():
+    for (mapping_key, mapping_value) in mapping:
         if isinstance(mapping_value, tuple):
-            mapping[mapping_key] = replace_in_nested_mapping(mapping_value, values)
-            if len(mapping[mapping_key]) == 0:
-                del(mapping[mapping_key])
+            definitions[mapping_key] = replace_in_nested_mapping(mapping_value, values)
 
         if mapping_value in values:
             if values[mapping_value]:
-                mapping[mapping_key] = values[mapping_value]
-            else:
-                del(mapping[mapping_key])
+                definitions[mapping_key] = values[mapping_value]
 
-    return tuple(mapping.items())
+    return tuple(definitions.items())
 
 
 def get_envelope(command):

--- a/silverpop/utils.py
+++ b/silverpop/utils.py
@@ -14,6 +14,8 @@ def replace_in_nested_mapping(mapping, values):
     for (mapping_key, mapping_value) in mapping:
         if isinstance(mapping_value, tuple):
             definitions[mapping_key] = replace_in_nested_mapping(mapping_value, values)
+            if len(definitions[mapping_key]) ==  0:
+                del definitions[mapping_key]
 
         if mapping_value in values:
             if values[mapping_value]:


### PR DESCRIPTION
The `replace_in_nested_mapping` function had problems running in python 3 since we mutate the OrderedDict mapping. If we make stuff the matched key lookups to their values into a new dict altogether, we can ensure that this works for both python 2 and python 3.

JIRA ticket here: https://svalbard.atlassian.net/browse/DEV-25130

Blocks some accounts-api work:
https://svalbard.atlassian.net/browse/CR2-165
https://svalbard.atlassian.net/browse/CR2-182