### PR TITLE
Silverpop is now Acoustic, long live Acoustic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,11 @@ from setuptools import setup, find_packages
 
 setup(
     name='pysilverpop',
-    version='0.2.5',
+    version='0.2.6',
     author='The Atlantic',
     author_email='programmers@theatlantic.com',
     url='https://github.com/theatlantic/pysilverpop',
-    description='Python wrapper for Silverpop.',
+    description='Python wrapper for Acoustic (formerly Silverpop).',
     packages=find_packages(),
     include_package_data=True,
     license='BSD',

--- a/silverpop/api.py
+++ b/silverpop/api.py
@@ -151,8 +151,8 @@ class Silverpop(object):
         retrieve an access token, even for the first grant. Generally, OAuth 2
         grants an access token and a refresh token initially.
     """
-    oauth_endpoint = "https://api%s.ibmmarketingcloud.com/oauth/token"
-    api_endpoint = "https://api%s.ibmmarketingcloud.com/XMLAPI"
+    oauth_endpoint = "https://api-campaign-us-%s.goacoustic.com/oauth/token"
+    api_endpoint = "https://api-campaign-us-%s.goacoustic.com/XMLAPI"
 
     def __init__(self, client_id, client_secret, refresh_token, server_number):
         self.oauth_endpoint = self.oauth_endpoint % server_number


### PR DESCRIPTION
Update URLs for the API calls, bump version.
At some point in the future, we could rename the package I suppose.